### PR TITLE
Multiple events

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,24 +53,17 @@ There are more, documentation is coming soon...
 
 ## Example output
 
-**Upcoming event from Scouts | Terrain**
+Youth see:
 
-Bushwalk
+![DragonSkin 2024](https://github.com/thdrmrphy/calendar/assets/130824397/beee215f-acb9-4ae0-af38-49442b1b0f7e)
 
-📍 Scout Campsite [///sizes.junior.unwell](https://w3w.co/sizes.junior.unwell) (near Merewether Heights, New South Wales)
+Parents see:
 
-🕒 9:00 AM - 3:00 PM
+![Parent version](https://github.com/thdrmrphy/calendar/assets/130824397/9a537341-f5d3-4719-8647-159494658120)
 
-🌱 Personal Growth Challenge
+Another example:
 
-
-A day hike through the bush of Scout Campsite.
-
-**Leader:** John Smith
-
-**Assistants:** James Blue, Amanda White
-
-View on [Scouts | Terrain](terrain.scouts.com.au/programming)
+![Excuse the bread](https://github.com/thdrmrphy/calendar/assets/130824397/17697d85-9464-4a7a-a193-977b5f53ef9e)
 
 ## To-do
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,3 @@ Another example:
 
 - Allow for what3words API bypass
 - Allow for parent topic bypass
-- Fix issues with overlapping events
-- Section also informs `connectColor`
-- Error handling for no events in JSON response but 200 OK

--- a/README.md
+++ b/README.md
@@ -2,10 +2,6 @@
 
 ## Scouts | Terrain -> JANDI incoming webhook integration
 
-### Currently under redevelopment.
-
----
-
 Calendar is a small Python script you can run as a daily cronjob. Given a login to Scouts | Terrain, it will find any events for the current day in a specified section that the account has access to, and post details on two JANDI topics.
 
 See all features below.
@@ -15,13 +11,14 @@ The base of this code is from [aiden2480/crest](https://github.com/aiden2480/cre
 ## Dependencies
 
 ```
-requests
 json
-datetime
-pytz
 re
-what3words
 os
+datetime
+functools
+requests
+pytz
+what3words
 ```
 
 ## config.json
@@ -33,7 +30,7 @@ os
 | `terrain_password`   | `password`                   | Your password for Terrain.                                                                                                                                                |
 | `youth_wh_url`       | `https://wh.jandi.com/...`   | The URL for the webhook set up in JANDI for the youth members' topic.                                                                                                     |
 | `parent_wh_url`      | `https://wh.jandi.com/...`   | The URL for the webhook set up in JANDI for the parents' topic.                                                                                                           |
-| `timezone`           | `Australia/Sydney`           | Your timezone (corrects for daylight saving)                                                                                                                              |
+| `timezone`           | `Australia/Sydney`           | Your timezone (automatically corrects for daylight saving)                                                                                                                              |
 | `section`            | `venturer`                   | The Section you wish to notify. This will be `joey`, `cub`, `scout`, `venturer` or `rover`.                                                                               |
 | `meeting_weekday`    | `null`                       | The day of the week on which the bot will send a "No meeting tonight" message if there's no event. Monday is `0`, Sunday is `6`. `null` disables this feature.            |
 | `what3words_api_key` | `ABCDEFGH`                   | The API key from what3words. Requests are free and unlimited for this script.                                                                                             |
@@ -41,15 +38,25 @@ os
 
 ## Features
 
-Sends a message (see sample output below) to the youth members' JANDI topic with full event details. 
+- Sends a message (see sample output below) to the youth members' JANDI topic with full event details. This includes:
+    - Name
+    - Location (including what3words addresses)
+    - Date and time (dynamically, based on event time and length)
+    - Challenge Area
+    - Description
+    - Leaders and Assistants
+    - A link to Terrain
+- Sends a message to any parents' topic with concise details. This includes:
+    - Name
+    - Location (including what3words addresses)
+    - Date and time (dynamically, based on event time and length)
+- Makes any what3words addresses clickable and highlights where they are in normal terms. Also highlights when they may be incorrect (i.e. outside Australia)
+- Only notifies of events starting in the next 24 hours after the script is run. Due to the way Terrain stores and retrieves events in UTC by default, this override comes in handy. It also means that events starting early (such as a dawn service for ANZAC Day) are communicated the day before, instead of after they commence. 
+- Given a regular meeting weekday set in the configuration, the script can inform JANDI users if there's nothing on. For example, if your meetings are normally on Tuesdays, but one week it's cancelled, the script lets everyone know.
+- The colour on the left of the JANDI message is in-line with Section branding.
+- Replaces names as specified in the configuration. 
 
-Sends a message to any parents' topic with concise details.
-
-Makes any what3words addresses clickable and highlights where they are in normal terms. Also highlights when they may be incorrect (i.e. outside Australia)
-
-Only notifies of events starting on the current day in the specified timezone. Due to the way Terrain stores and retrieves events in UTC, there are known issues with this.
-
-There are more, documentation is coming soon...
+and more...
 
 ## Example output
 

--- a/calendar-bot.py
+++ b/calendar-bot.py
@@ -185,7 +185,7 @@ def send_message(event_id):
 
     youth_message_content = {
         "body": "Upcoming event from Scouts | Terrain",
-        "connectColor": "#99002b",
+        "connectColor": f"{section_colour}",
         "connectInfo": [{
             "title": title,
             "description": f"📍 {location}\n🕒 {formatted_start_time} - {formatted_end_time}\n{formatted_challenge}\n\n{description}\n\n{lead_string}\n\n{assistant_string}\n\nView on [Scouts | Terrain](terrain.scouts.com.au/programming)"
@@ -194,7 +194,7 @@ def send_message(event_id):
 
     parent_message_content = {
         "body": f"Upcoming event for {section_full_name}s",
-        "connectColor": "#99002b",
+        "connectColor": f"{section_colour}",
         "connectInfo": [{
             "title": title,
             "description": f"📍 {location}\n🕒 {formatted_start_time} - {formatted_end_time}"
@@ -239,6 +239,15 @@ section_names = {
     "rover": "Rover Scout"
 }
 section_full_name = section_names.get(section, section)
+
+section_colours = {
+    "joey": "#b86125",
+    "cub": "#ffc72c",
+    "scout": "#00b140",
+    "venturer": "#9d2235",
+    "rover": "#da291c"
+}
+section_colour = section_colours.get(section, section)
 
 session = generate_session(terrain_username, terrain_password)
 event_list = get_events(session, get_member_id(session))

--- a/calendar-bot.py
+++ b/calendar-bot.py
@@ -149,15 +149,18 @@ filepath = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'config.json
 with open(filepath) as config:
     config = json.load(config)
 
-terrain_username = config['terrain_username']
-terrain_password = config['terrain_password']
-youth_wh_url = config['youth_wh_url']
-parent_wh_url = config['parent_wh_url']
-local_timezone = config['timezone']
-section = config['section']
-meeting_weekday = config['meeting_weekday']
-what3words_api_key = config['what3words_api_key']
-name_replacements = config['name_replacements']
+try:
+    terrain_username = config['terrain_username']
+    terrain_password = config['terrain_password']
+    youth_wh_url = config['youth_wh_url']
+    parent_wh_url = config['parent_wh_url']
+    local_timezone = config['timezone']
+    section = config['section']
+    meeting_weekday = config['meeting_weekday']
+    what3words_api_key = config['what3words_api_key']
+    name_replacements = config['name_replacements']
+except KeyError as e:
+    print(f"Configuration error: {e} is missing in the configuration.")
 
 section_names = {
     "joey": "Joey Scout",

--- a/calendar-bot.py
+++ b/calendar-bot.py
@@ -45,10 +45,8 @@ def get_member_id(connection: requests.Session) -> str:
     return member_data["profiles"][0]["member"]["id"]
 
 def get_events(connection: requests.Session, member: str) -> list:
-    start_datetime = datetime.now().date() - timedelta(days=1)
-    end_datetime = datetime.now().date() + timedelta(days=1)
-    start_datetime = start_datetime.isoformat()
-    end_datetime = end_datetime.isoformat()
+    start_datetime = (datetime.now().date() - timedelta(days=1)).isoformat()
+    end_datetime = (datetime.now().date() + timedelta(days=1)).isoformat()
     url = f"https://events.terrain.scouts.com.au/members/{member}/events?start_datetime={start_datetime}&end_datetime={end_datetime}"
     event_data = connection.get(url).json()
     return event_data

--- a/calendar-bot.py
+++ b/calendar-bot.py
@@ -188,7 +188,7 @@ def send_message(event_id):
         "connectColor": f"{section_colour}",
         "connectInfo": [{
             "title": title,
-            "description": f"📍 {location}\n🕒 {formatted_start_time} - {formatted_end_time}\n{formatted_challenge}\n\n{description}\n\n{lead_string}\n\n{assistant_string}\n\nView on [Scouts | Terrain](terrain.scouts.com.au/programming)"
+            "description": f"📍 {location}\n🕒 {formatted_start_time} - {formatted_end_time}\n{formatted_challenge}\n\n{description}\n\n{lead_string}\n{assistant_string}\n\nView on [Scouts | Terrain](terrain.scouts.com.au/programming)"
         }]
     }
 

--- a/calendar-bot.py
+++ b/calendar-bot.py
@@ -4,6 +4,7 @@ import json
 import re
 import os
 from datetime import datetime, timedelta
+from functools import lru_cache
 
 import requests
 import pytz
@@ -44,20 +45,21 @@ def get_member_id(connection: requests.Session) -> str:
     return member_data["profiles"][0]["member"]["id"]
 
 def get_events(connection: requests.Session, member: str) -> list:
-    start_datetime = datetime.now().date().isoformat()
+    start_datetime = datetime.now().date() - timedelta(days=1)
     end_datetime = datetime.now().date() + timedelta(days=1)
+    start_datetime = start_datetime.isoformat()
     end_datetime = end_datetime.isoformat()
     url = f"https://events.terrain.scouts.com.au/members/{member}/events?start_datetime={start_datetime}&end_datetime={end_datetime}"
     event_data = connection.get(url).json()
-    print(json.dumps(event_data))
     return event_data
 
+@lru_cache(maxsize=None)
 def get_event_info(connection: requests.Session, id: str):
     url = f"https://events.terrain.scouts.com.au/events/{id}"
     event_data = connection.get(url).json()
     return event_data
 
-def message_none(wh_url, terrain_mention):
+def jandi_none(wh_url, terrain_mention):
     headers = {'Content-Type': 'application/json'}
     if terrain_mention:
         content = {
@@ -65,7 +67,7 @@ def message_none(wh_url, terrain_mention):
         }
     else:
         content = {
-            "body": f"**No {section_fancy} meeting tonight, according to our online calendar.**\n\n*Note: If it's term-time, this may be wrong. Please refer to any amendments below.*",
+            "body": f"**No {section_full_name} meeting tonight, according to our online calendar.**\n\n*Note: If it's term-time, this may be wrong. Please refer to any amendments below.*",
         }
     message_data = json.dumps(content)
     response = requests.post(wh_url, headers=headers, data=message_data, timeout=10)
@@ -75,7 +77,7 @@ def message_none(wh_url, terrain_mention):
     else:
         print("Failed to send message to Jandi. Error:", response.text)
 
-def message_meeting(content, wh_url):
+def jandi_details(content, wh_url):
     headers = {'Content-Type': 'application/json'}
     message_data = json.dumps(content)
     response = requests.post(wh_url, headers=headers, data=message_data, timeout=10)
@@ -144,8 +146,75 @@ def location_append_w3w(loc_string):
 
     return loc_string
 
-filepath = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'config.json')
+def event_date_filter(start_datetime):
+    start_datetime_local = datetime.fromisoformat(start_datetime).astimezone(local_timezone)
+    time_difference = start_datetime_local - datetime.now(local_timezone)
 
+    if not timedelta(hours=0) <= time_difference <= timedelta(hours=24):
+        print(f"Event does not begin in the next 24 hours;")
+        return False
+    
+    return True
+
+def send_message(event_id):
+    event_info = get_event_info(session, event_id)
+    
+    title = event_info['title']
+
+    location = location_append_w3w(event_info['location'])
+
+    formatted_challenge = format_challenge(event_info['challenge_area'])
+
+    start_datetime_local = datetime.fromisoformat(event_info['start_datetime']).astimezone(local_timezone)
+    end_datetime_local = datetime.fromisoformat(event_info['end_datetime']).astimezone(local_timezone)
+
+    if start_datetime_local.date() != end_datetime_local.date():
+        formatted_start_time = start_datetime_local.strftime("%-I:%M %p, %A %-d %B")
+        formatted_end_time = end_datetime_local.strftime("%-I:%M %p, %A %-d %B")
+    elif start_datetime_local.date() != datetime.now(local_timezone).date():
+        formatted_start_time = start_datetime_local.strftime("Tomorrow (%A %-d %B) %-I:%M %p")
+        formatted_end_time = end_datetime_local.strftime("%-I:%M %p")
+    else:
+        formatted_start_time = start_datetime_local.strftime("%-I:%M %p")
+        formatted_end_time = end_datetime_local.strftime("%-I:%M %p")
+
+    if 'description' in event_info:
+        description = event_info['description']
+    else: description = "No description given"
+
+    lead_string = fancify_leads(replace_names(event_info['attendance']['leader_members']))
+    assistant_string = fancify_assists(replace_names(event_info['attendance']['assistant_members']))
+
+    youth_message_content = {
+        "body": "Upcoming event from Scouts | Terrain",
+        "connectColor": "#99002b",
+        "connectInfo": [{
+            "title": title,
+            "description": f"📍 {location}\n🕒 {formatted_start_time} - {formatted_end_time}\n{formatted_challenge}\n\n{description}\n\n{lead_string}\n\n{assistant_string}\n\nView on [Scouts | Terrain](terrain.scouts.com.au/programming)"
+        }]
+    }
+
+    parent_message_content = {
+        "body": f"Upcoming event for {section_full_name}s",
+        "connectColor": "#99002b",
+        "connectInfo": [{
+            "title": title,
+            "description": f"📍 {location}\n🕒 {formatted_start_time} - {formatted_end_time}"
+        }]
+    }
+
+    jandi_details(youth_message_content, youth_wh_url)
+    jandi_details(parent_message_content, parent_wh_url)
+
+    print(youth_message_content)
+    print(parent_message_content)
+
+def process_event(event_id):
+    event_info = get_event_info(session, event_id)
+    print(f"Event: {event_info['title']}\nJSON:\n" + json.dumps(event_info))
+    send_message(event_id)
+
+filepath = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'config.json')
 with open(filepath) as config:
     config = json.load(config)
 
@@ -162,6 +231,8 @@ try:
 except KeyError as e:
     print(f"Configuration error: {e} is missing in the configuration.")
 
+local_timezone = pytz.timezone(local_timezone)
+
 section_names = {
     "joey": "Joey Scout",
     "cub": "Cub Scout",
@@ -169,81 +240,39 @@ section_names = {
     "venturer": "Venturer Scout",
     "rover": "Rover Scout"
 }
-section_fancy = section_names.get(section, section)
+section_full_name = section_names.get(section, section)
 
 session = generate_session(terrain_username, terrain_password)
-
 event_list = get_events(session, get_member_id(session))
-if 'results' in event_list:
-    for event in event_list['results']:
-        if event['section'] == f'{section}' and event['invitee_type'] == 'unit':
-            event_id = event['id']
-            break
-        else:
-            if datetime.now().weekday() == meeting_weekday:
-                message_none(youth_wh_url, True)
-                message_none(parent_wh_url, False)
-                quit()
-            elif meeting_weekday is not None and 0 <= meeting_weekday <= 6:
-                print("No events today.")
-                quit()
-            else:
-                print("No events today, and no regular weekday set.")
-                quit()
-else:
+
+if not 'results' in event_list:
     print("Error getting event list")
     quit()
-
-event_info = get_event_info(session, event_id)
-
-local_timezone = pytz.timezone(local_timezone)
-start_datetime_local = datetime.fromisoformat(event_info['start_datetime']).astimezone(local_timezone)
-end_datetime_local = datetime.fromisoformat(event_info['end_datetime']).astimezone(local_timezone)
-
-if start_datetime_local.date() != datetime.now(local_timezone).date():
-    print("Event returned does not begin today in local timezone")
+elif not event_list['results']:
+    print("No events returned.")
     quit()
-
-title = event_info['title']
-
-location = location_append_w3w(event_info['location'])
-
-formatted_challenge = format_challenge(event_info['challenge_area'])
-
-if start_datetime_local.date() != end_datetime_local.date():
-    formatted_start_time = start_datetime_local.strftime("%-I:%M %p, %A %-d %B")
-    formatted_end_time = end_datetime_local.strftime("%-I:%M %p, %A %-d %B")
 else:
-    formatted_start_time = start_datetime_local.strftime("%-I:%M %p")
-    formatted_end_time = end_datetime_local.strftime("%-I:%M %p")
+    print(json.dumps(event_list))
+    event_today = False
 
-if 'description' in event_info:
-    description = event_info['description']
-else: description = "No description given"
+for event in event_list['results']:
+    if event['section'] == f'{section}' and event['invitee_type'] == 'unit' and event_date_filter(event['start_datetime']):
+        event_today = True
+        event_id = event['id']
+        print(event_id)
+        process_event(event_id)
+    else:
+        print(f"Event {event['id']} does not fit criteria (datetime/unit)")
 
-lead_string = fancify_leads(replace_names(event_info['attendance']['leader_members']))
-assistant_string = fancify_assists(replace_names(event_info['attendance']['assistant_members']))
-
-youth_message_content = {
-    "body": "Upcoming event from Scouts | Terrain",
-    "connectColor": "#99002b",
-    "connectInfo": [{
-        "title": title,
-        "description": f"📍 {location}\n🕒 {formatted_start_time} - {formatted_end_time}\n{formatted_challenge}\n\n{description}\n\n{lead_string}\n\n{assistant_string}\n\nView on [Scouts | Terrain](terrain.scouts.com.au/programming)"
-    }]
-}
-
-parent_message_content = {
-    "body": f"Upcoming event for {section_fancy}s",
-    "connectColor": "#99002b",
-    "connectInfo": [{
-        "title": title,
-        "description": f"📍 {location}\n🕒 {formatted_start_time} - {formatted_end_time}"
-    }]
-}
-
-message_meeting(youth_message_content, youth_wh_url)
-message_meeting(parent_message_content, parent_wh_url)
-
-print(youth_message_content)
-print(parent_message_content)
+if event_today == False:
+    if datetime.now().weekday() == meeting_weekday:
+        print("No event on regular meeting day. Sending message.")
+        jandi_none(youth_wh_url, True)
+        jandi_none(parent_wh_url, False)
+        quit()
+    elif meeting_weekday is not None and 0 <= meeting_weekday <= 6:
+        print("No events today.")
+        quit()
+    else:
+        print("No events today, and no regular weekday set.")
+        quit()

--- a/calendar-bot.py
+++ b/calendar-bot.py
@@ -257,7 +257,7 @@ if not 'results' in event_list:
     quit()
 elif not event_list['results']:
     print("No events returned.")
-    quit()
+    event_today = False
 else:
     print(json.dumps(event_list))
     event_today = False


### PR DESCRIPTION
Lots of updates and polishing it all off a bit. Still a couple of things on the to-do list but they're not difficult, I'll get around to them eventually. 

The script now handles multiple events (yay) and somewhat more importantly will catch all events in the 24 hours after the script is run, and nothing else, which makes a bit more sense. It also fixes the stupid Terrain UTC issue and adapts for daylight saving and everything. Multiple-day events have the dates included in the message and if the event is tomorrow, but before the next script run, it'll indicate that too. 

A few other things cleaned up in the code but also importantly is, of course, the Section colour dictionary that now allows all JANDI Connect messages to be correctly coloured. Oh, and, some logic has changed to accomodate for multiple events, so as an unintended side effect the logging is better and I stuck an `@lru_cache` in there to speed it up and not abuse Terrain itself (or at least AWS) with additional requests.